### PR TITLE
adding note about timeouts

### DIFF
--- a/hub_orientation.md
+++ b/hub_orientation.md
@@ -41,3 +41,8 @@ The following is provided:
   - Python
   - R
   - C++
+
+- **User Experience:**
+  - Each user gets the same Python and R packages pre-installed
+  - Shared directories (read/write for admins/instructors, read-only for everyone else)
+  - *Important!* All user sessions have a hard limit of 12 hours.  If a user session is automatically killed at 12 hours, the user will need to re-authenticate to pick up where they were last at!


### PR DESCRIPTION
user pods are killed after 12 hours, even if they're still active.  this is to save resources, and force culling of idle pods where the user doesn't log out and leaves a tab open.

sadly, there's no easy way to notify the user when they're approaching this limit (yet).  i will investigate adding something like this but i can't guarantee that it will be possible (or easy).